### PR TITLE
Add support for Tailwind v1.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,26 @@
-module.exports = function colorVars({ colors, strategy = 'override', colorTransform } = {}) {
-  return function tailwindColorVarsPlugin({ addUtilities, addComponents, e, prefix, config }) {
+module.exports = function ({
+  colors,
+  strategy = 'override',
+  colorTransform = (color) => color,
+} = {}) {
+  return function ({ addComponents, e, config }) {
     if (colors && typeof colors === 'object') {
       if (strategy === 'override') {
-        colors = Object.assign({}, config('colors'), colors)
+        colors = Object.assign({}, config('theme.colors'), colors)
       } else if (strategy === 'replace') {
-        //colors = colors
+        colors = colors
       } else if (strategy === 'extend') {
-        colors = Object.assign({}, colors, config('colors'))
+        colors = Object.assign({}, colors, config('theme.colors'))
       }
     } else {
-      colors = config('colors')
+      colors = config('theme.colors')
     }
-    let names = Object.keys(colors)
-    let root = {}, css = {
-      ':root': root,
-    }
-    names.forEach(col => {
-      root[`--${e(col)}`] = colorTransform ? colorTransform(colors[col]) : colors[col]
+
+    let root = {}
+    Object.keys(colors).forEach(colorKey => {
+      root[`--${e(colorKey)}`] = colorTransform(colors[colorKey])
     })
-    addComponents(css)
+
+    addComponents({ ':root': root })
   }
 }

--- a/index.js
+++ b/index.js
@@ -4,16 +4,18 @@ module.exports = function ({
   colorTransform = (color) => color,
 } = {}) {
   return function ({ addComponents, e, config }) {
+    const configColors = config('theme.colors', config('colors'))
+
     if (colors && typeof colors === 'object') {
       if (strategy === 'override') {
-        colors = Object.assign({}, config('theme.colors'), colors)
+        colors = Object.assign({}, configColors, colors)
       } else if (strategy === 'replace') {
         colors = colors
       } else if (strategy === 'extend') {
-        colors = Object.assign({}, colors, config('theme.colors'))
+        colors = Object.assign({}, colors, configColors)
       }
     } else {
-      colors = config('theme.colors')
+      colors = configColors
     }
 
     let root = {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "tailwind-color-vars",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,13 @@
   },
   "scripts": {},
   "author": "n1kk",
-  "keywords": ["tailwindcss", "tailwind", "plugin", "colors", "css variables", "css vars"],
+  "keywords": [
+    "tailwindcss",
+    "tailwind",
+    "plugin",
+    "colors",
+    "css variables",
+    "css vars"
+  ],
   "license": "MIT"
 }


### PR DESCRIPTION
This PR changed how the default values are retrieved from the config file to allow using it with Tailwind v1.x.

It also gets rid of some unnecessary variables and adds a default `colorTransform()` that allows us to get rid of the ternary inside the loop.

@derevandal was having issues in https://github.com/tailwindcss/tailwindcss/issues/861 and this fixed them for him. Haven't tested much further so please let me know if there something I missed so I can fix it.